### PR TITLE
[feat]: 부스배치도 기능 추가 및 공지사항 예외처리 개선

### DIFF
--- a/src/main/java/com/capstone7/ptufestival/auth/config/SecurityConfig.java
+++ b/src/main/java/com/capstone7/ptufestival/auth/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**", "/api/user/**", "/api/notice/read/**", "/api/timetable/**", "api-docs/**", "/swagger", "swagger-ui/**").permitAll()
+                        .requestMatchers("/api/auth/**", "/api/user/**", "/api/notice/read/**", "/api/timetable/**", "/api/booth/**","api-docs/**", "/swagger", "swagger-ui/**").permitAll()
                         .requestMatchers("/api/notice/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/capstone7/ptufestival/booth/controller/BoothController.java
+++ b/src/main/java/com/capstone7/ptufestival/booth/controller/BoothController.java
@@ -1,0 +1,47 @@
+package com.capstone7.ptufestival.booth.controller;
+
+import com.capstone7.ptufestival.booth.service.BoothService;
+import com.capstone7.ptufestival.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/booth")
+@Tag(name = "부스배치도", description = "부스배치도 조회 API")
+public class BoothController {
+
+    private final BoothService boothService;
+
+    public BoothController(BoothService boothService) {
+        this.boothService = boothService;
+    }
+
+    @Operation(summary = "id별 부스 조회", description = "id를 Path Param로 전달하면 해당 id의 부스를 조회합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getBooth(@PathVariable int id)
+    {
+
+        return ApiResponse.success(boothService.findBooth(id));
+    }
+
+    @Operation(summary = "id나 theme별 부스 조회", description = "theme(푸드 | 체험 | 푸드트럭 중 하나)를 Path Param로 전달하면 해당 theme의 부스를 조회합니다.")
+    @GetMapping("/theme/{theme}")
+    public ResponseEntity<?> getBoothsByTheme(@PathVariable String theme)
+    {
+
+        return ApiResponse.success(boothService.findBoothsByTheme(theme));
+    }
+
+    @Operation(summary = "id별 부스 세부사항 조회", description = "id를 Path Param으로 전달하면 해당 id의 부스 세부사항을 조회합니다.")
+    @GetMapping("/detail/{id}")
+    public ResponseEntity<?> getBoothDetail(@PathVariable int id) {
+
+        return ApiResponse.success(boothService.findBoothDetail(id));
+    }
+
+}

--- a/src/main/java/com/capstone7/ptufestival/booth/dto/BoothDetailResponseDto.java
+++ b/src/main/java/com/capstone7/ptufestival/booth/dto/BoothDetailResponseDto.java
@@ -1,0 +1,24 @@
+package com.capstone7.ptufestival.booth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class BoothDetailResponseDto {
+
+    private int id;
+    private String name;
+    private String department;
+    private String theme;
+    private String description;
+    private String location;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private List<ServiceDto> services;
+}

--- a/src/main/java/com/capstone7/ptufestival/booth/dto/BoothResponseDto.java
+++ b/src/main/java/com/capstone7/ptufestival/booth/dto/BoothResponseDto.java
@@ -1,0 +1,24 @@
+package com.capstone7.ptufestival.booth.dto;
+
+import com.capstone7.ptufestival.booth.entity.Booth;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.format.DateTimeFormatter;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@Builder
+public class BoothResponseDto {
+
+    private int id;
+    private String name;
+    private String department;
+    private String theme;
+    private String location;
+    private String time;
+    private String menu;
+
+}

--- a/src/main/java/com/capstone7/ptufestival/booth/dto/ServiceDto.java
+++ b/src/main/java/com/capstone7/ptufestival/booth/dto/ServiceDto.java
@@ -1,0 +1,18 @@
+package com.capstone7.ptufestival.booth.dto;
+
+import com.capstone7.ptufestival.booth.entity.Service;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ServiceDto {
+    private int id;
+    private String serviceName;
+    private int price;
+    private Boolean soldOut;
+
+}

--- a/src/main/java/com/capstone7/ptufestival/booth/entity/Booth.java
+++ b/src/main/java/com/capstone7/ptufestival/booth/entity/Booth.java
@@ -1,0 +1,39 @@
+package com.capstone7.ptufestival.booth.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Entity
+@Getter
+public class Booth {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String department;
+
+    @Column(nullable = false)
+    private String theme;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    private String location;
+
+    @Column(name = "start_time")
+    private LocalTime startTime;
+
+    @Column(name = "end_time")
+    private LocalTime endTime;
+
+    @OneToMany(mappedBy = "booth", cascade = CascadeType.ALL)
+    private List<Service> services;
+}

--- a/src/main/java/com/capstone7/ptufestival/booth/entity/Service.java
+++ b/src/main/java/com/capstone7/ptufestival/booth/entity/Service.java
@@ -1,0 +1,27 @@
+package com.capstone7.ptufestival.booth.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Service {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_id")
+    private Booth booth;
+
+    @Column(name = "service_name", nullable = false)
+    private String serviceName;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(name = "sold_out")
+    private Boolean soldOut;
+
+}

--- a/src/main/java/com/capstone7/ptufestival/booth/repository/BoothRepository.java
+++ b/src/main/java/com/capstone7/ptufestival/booth/repository/BoothRepository.java
@@ -1,0 +1,18 @@
+package com.capstone7.ptufestival.booth.repository;
+
+import com.capstone7.ptufestival.booth.entity.Booth;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BoothRepository extends JpaRepository<Booth, Integer> {
+
+    List<Booth> findByTheme(String theme);
+
+    Optional<Booth> findById(int id);
+}

--- a/src/main/java/com/capstone7/ptufestival/booth/service/BoothService.java
+++ b/src/main/java/com/capstone7/ptufestival/booth/service/BoothService.java
@@ -1,0 +1,104 @@
+package com.capstone7.ptufestival.booth.service;
+
+import com.capstone7.ptufestival.booth.dto.BoothDetailResponseDto;
+import com.capstone7.ptufestival.booth.dto.BoothResponseDto;
+import com.capstone7.ptufestival.booth.dto.ServiceDto;
+import com.capstone7.ptufestival.booth.entity.Booth;
+import com.capstone7.ptufestival.booth.repository.BoothRepository;
+import com.capstone7.ptufestival.booth.entity.Service;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@org.springframework.stereotype.Service
+public class BoothService {
+
+    private final BoothRepository boothRepository;
+    public BoothService(BoothRepository boothRepository) {
+        this.boothRepository = boothRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public BoothResponseDto findBooth(int id) {
+
+        Booth booth = boothRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("해당 id의 부스를 찾을 수 없습니다."));
+        BoothResponseDto boothResponseDto = createBoothDto(booth);
+
+        return boothResponseDto;
+    }
+
+    @Transactional(readOnly = true)
+    public List<BoothResponseDto> findBoothsByTheme(String theme) {
+
+        List<Booth> booths = boothRepository.findByTheme(theme);
+
+        if (booths.isEmpty()) {
+            throw new EntityNotFoundException("해당 theme의 부스를 찾을 수 없습니다.");
+        }
+
+        List<BoothResponseDto> boothResponseDtos = new ArrayList<>();
+        for (Booth booth : booths) {
+
+            BoothResponseDto boothResponseDto = createBoothDto(booth);
+            boothResponseDtos.add(boothResponseDto);
+        }
+        return boothResponseDtos;
+    }
+
+    @Transactional(readOnly = true)
+    public BoothDetailResponseDto findBoothDetail(int id) {
+
+        Booth booth = boothRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("해당 id의 부스를 찾을 수 없습니다."));
+
+        BoothDetailResponseDto boothResponseDto = BoothDetailResponseDto.builder()
+                .id(booth.getId())
+                .name(booth.getName())
+                .department(booth.getDepartment())
+                .theme(booth.getTheme())
+                .description(booth.getDescription())
+                .endTime(booth.getEndTime())
+                .services(booth.getServices().stream()
+                        .map(BoothService::createServiceDto)
+                        .collect(Collectors.toList()))
+                .build();
+
+        return boothResponseDto;
+    }
+
+    static BoothResponseDto createBoothDto(Booth booth) {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+
+        String serviceName = booth.getServices().stream()         // Booth에 속한 Service 리스트
+                .map(Service -> Service.getServiceName())  // 각 Service의 serviceName 추출
+                .collect(Collectors.joining(", "));       // ", "로 구분하여 하나의 String으로 합침
+
+        BoothResponseDto dto = BoothResponseDto.builder()
+                .id(booth.getId())
+                .name(booth.getName())
+                .department(booth.getDepartment())
+                .theme(booth.getTheme())
+                .location(booth.getLocation())
+                .time(booth.getStartTime().format(formatter) + " ~ " + booth.getEndTime().format(formatter))
+                .menu(serviceName)
+                .build();
+
+        return dto;
+    }
+
+    static ServiceDto createServiceDto(Service service) {
+
+        ServiceDto dto = ServiceDto.builder()
+                .id(service.getId())
+                .serviceName(service.getServiceName())
+                .price(service.getPrice())
+                .soldOut(service.getSoldOut())
+                .build();
+
+        return dto;
+    }
+}

--- a/src/main/java/com/capstone7/ptufestival/notice/controller/NoticeController.java
+++ b/src/main/java/com/capstone7/ptufestival/notice/controller/NoticeController.java
@@ -1,5 +1,6 @@
 package com.capstone7.ptufestival.notice.controller;
 
+import com.capstone7.ptufestival.common.dto.ApiResponse;
 import com.capstone7.ptufestival.notice.dto.NoticeRequestDto;
 import com.capstone7.ptufestival.auth.model.User;
 import com.capstone7.ptufestival.notice.service.NoticeService;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/notice")
-@Tag(name = "Notice", description = "공지사항 CRUD API")
+@Tag(name = "공지사항", description = "공지사항 CRUD API")
 public class NoticeController {
 
     private final NoticeService noticeService;
@@ -22,41 +23,43 @@ public class NoticeController {
 
     @Operation(summary = "공지사항 생성", description = "관리자 권한을 가진 클라이언트가 해당 형식의 데이터를 Body에 담아 전달해주면 공지사항을 생성해줍니다.")
     @PostMapping("/create")
-    public ResponseEntity<String> createNotice(@RequestBody NoticeRequestDto dto, @AuthenticationPrincipal User user) {
+    public ResponseEntity<?> createNotice(@RequestBody NoticeRequestDto dto, @AuthenticationPrincipal User user) {
+
         noticeService.createNotice(dto, user);
-        return ResponseEntity.ok("공지사항이 성공적으로 생성되었습니다.");
+        return ApiResponse.success("공지사항이 성공적으로 생성되었습니다.");
     }
 
     @Operation(summary = "단일 공지사항 조회", description = "클라이언트가 조회할 데이터를 {id}로 구분해서 요청해주면 해당 id의 공지사항을 반환해줍니다.")
     @GetMapping("/read/{id}")
     public ResponseEntity<?> readNotice(@PathVariable("id") int id) {
-        return ResponseEntity.ok(noticeService.readNotice(id));
+
+        return ApiResponse.success(noticeService.readNotice(id));
     }
 
     @Operation(summary = "전체 공지사항 목록 조회", description = "DB에 저장된 모든 공지사항을 JSON 형식의 리스트로 반환해줍니다.")
     @GetMapping("/read")
     public ResponseEntity<?> readNotice() {
-        return ResponseEntity.ok(noticeService.readAllNotices());
+
+        return ApiResponse.success(noticeService.readAllNotices());
     }
 
     @Operation(summary = "공지사항 수정", description = "관리자 권한을 가진 클라이언트가 수정할 데이터를 {id}로 구분해서 요청해주면 해당 id의 공지사항을 수정해줍니다.")
     @PutMapping("/update/{id}")
-    public ResponseEntity<String> updateNotice(
+    public ResponseEntity<?> updateNotice(
             @PathVariable("id") int id, @RequestBody NoticeRequestDto dto, @AuthenticationPrincipal User user
     ) {
 
         noticeService.updateNotice(id, dto);
-        return ResponseEntity.ok("공지사항이 성공적으로 수정되었습니다.");
+        return ApiResponse.success("공지사항이 성공적으로 수정되었습니다.");
     }
 
     @Operation(summary = "공지사항 삭제", description = "관리자 권한을 가진 클라이언트가 삭제할 데이터를 {id}로 구분해서 요청해주면 해당 id의 공지사항을 삭제해줍니다.")
     @DeleteMapping("/delete/{id}")
-    public ResponseEntity<String> deleteNotice(
+    public ResponseEntity<?> deleteNotice(
             @PathVariable("id") int id, @AuthenticationPrincipal User user
     ) {
 
-        System.out.println(id);
         noticeService.deleteNotice(id);
-        return ResponseEntity.ok("공지사항이 성공적으로 삭제되었습니다.");
+        return ApiResponse.success("공지사항이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/capstone7/ptufestival/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/capstone7/ptufestival/notice/repository/NoticeRepository.java
@@ -5,11 +5,14 @@ import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Integer> {
     Optional<Notice> findById(int id);
+
+    List<Notice> findAllByOrderByIdDesc();
 
     @Transactional
     void deleteById(int id);

--- a/src/main/java/com/capstone7/ptufestival/notice/service/NoticeService.java
+++ b/src/main/java/com/capstone7/ptufestival/notice/service/NoticeService.java
@@ -6,6 +6,7 @@ import com.capstone7.ptufestival.notice.dto.NoticeResponseDto;
 import com.capstone7.ptufestival.auth.jwt.JwtUtil;
 import com.capstone7.ptufestival.notice.entity.Notice;
 import com.capstone7.ptufestival.notice.repository.NoticeRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,16 +25,6 @@ public class NoticeService {
         this.jwtUtil = jwtUtil;
     }
 
-//    public Boolean hasAccess(int id, String token) {
-//
-//        String role = jwtUtil.extractRole(token.split(" ")[1]);
-//
-//        if (role.equals("admin")) {
-//            return true;
-//        }
-//        return false;
-//    }
-
     // 공지사항 생성
     @Transactional
     public void createNotice(NoticeRequestDto dto, User user) {
@@ -50,7 +41,7 @@ public class NoticeService {
     @Transactional()
     public NoticeResponseDto readNotice(int id) {
 
-        Notice notice = noticeRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 id의 공지사항을 찾을 수 없습니다."));
+        Notice notice = noticeRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("해당 id의 공지사항을 찾을 수 없습니다."));
 
         notice.setViewCount(notice.getViewCount() + 1);
         noticeRepository.save(notice);
@@ -72,7 +63,7 @@ public class NoticeService {
     @Transactional(readOnly = true)
     public List<NoticeResponseDto> readAllNotices() {
 
-        List<Notice> notices = noticeRepository.findAll();
+        List<Notice> notices = noticeRepository.findAllByOrderByIdDesc();
         List<NoticeResponseDto> noticeDtos = new ArrayList<>();
 
         for (Notice notice : notices) {
@@ -95,7 +86,7 @@ public class NoticeService {
     @Transactional
     public void updateNotice(int id, NoticeRequestDto dto) {
 
-        Notice notice = noticeRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 id의 공지사항을 찾을 수 없습니다."));
+        Notice notice = noticeRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("해당 id의 공지사항을 찾을 수 없습니다."));
 
         notice.setTitle(dto.getTitle());
         notice.setContent(dto.getContent());
@@ -107,6 +98,7 @@ public class NoticeService {
     @Transactional
     public void deleteNotice(int id) {
 
+        noticeRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("해당 id의 공지사항을 찾을 수 없습니다."));
         noticeRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

부스배치도 기능(API 3종)을 추가했습니다.  
id별 부스와 테마별 부스 리스트를 조회할 수 있습니다.
id별로 부스 세부사항을 조회할 수 있습니다.

## 🛠️ 작업 내용

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링

## 💬 공유사항 to 리뷰어

- 프론트에서는 `GET /api/booth/{id}`, `GET /api/booth/theme{theme}`, `GET /api/booth/detail/{id}`를 적절히 호출하도록 구성하면 됩니다.
- 테마에는 `푸드 | 체험 | 푸드트럭` 총 3가지가 있습니다.  이 중 하나를 Path Param로 전달하면 됩니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
